### PR TITLE
Add styling for `hr` so it's visible

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -299,12 +299,14 @@ thead
     color: var(--inline-code) !important;
 }
 
-.markdown-preview-view hr {
+.markdown-preview-view hr
+{
     border: none;
     border-top: 1px solid var(--text-faint);
 }
 
-.markdown-source-view hr {
+.markdown-source-view hr
+{
     border: none;
     border-top: 1px solid var(--text-faint);
 }

--- a/obsidian.css
+++ b/obsidian.css
@@ -299,6 +299,16 @@ thead
     color: var(--inline-code) !important;
 }
 
+.markdown-preview-view hr {
+    border: none;
+    border-top: 1px solid var(--text-faint);
+}
+
+.markdown-source-view hr {
+    border: none;
+    border-top: 1px solid var(--text-faint);
+}
+
 .cm-s-obsidian,
 .cm-inline-code
 {


### PR DESCRIPTION
Closes #1 

Example markdown:
```md
Example text

---

Example text
```

Result looks like this:

<img width="744" alt="image" src="https://user-images.githubusercontent.com/5663042/195485255-0417b4bc-80a0-4d0b-af7c-88516ecff9f3.png">
